### PR TITLE
Fix for get_product_historic_rates function

### DIFF
--- a/coinbasepro/public_client.py
+++ b/coinbasepro/public_client.py
@@ -146,13 +146,13 @@ class PublicClient(object):
         return self._send_paginated_message('/products/{}/trades'
                                             .format(product_id))
 
-    def get_product_historic_rates(self, product_id, start=None, end=None,
+    def get_product_historic_rates(self, product_id, start=None, stop=None,
                                    granularity=None):
         """Historic rates for a product.
 
         Rates are returned in grouped buckets based on requested
         `granularity`. If start, end, and granularity aren't provided,
-        the exchange will assume some (currently unknown) default values.
+        the exchange will provide the latest 300 ticks with 60s granularity (one minute).
 
         Historical rate data may be incomplete. No data is published for
         intervals where there are no ticks.
@@ -161,9 +161,9 @@ class PublicClient(object):
         If you need real-time information, use the trade and book
         endpoints along with the websocket feed.
 
-        The maximum number of data points for a single request is 200
+        The maximum number of data points for a single request is 300
         candles. If your selection of start/end time and granularity
-        will result in more than 200 data points, your request will be
+        will result in more than 300 data points, your request will be
         rejected. If you wish to retrieve fine granularity data over a
         larger time range, you will need to make multiple requests with
         new start/end ranges.
@@ -177,7 +177,7 @@ class PublicClient(object):
         Returns:
             list: Historic candle data. Example::
                 [
-                    [ time, low, high, open, close, volume ],
+                    [ epoch time, low, high, open, close, volume ],
                     [ 1415398768, 0.32, 4.2, 0.35, 4.2, 12.3 ],
                     ...
                 ]
@@ -186,8 +186,8 @@ class PublicClient(object):
         params = {}
         if start is not None:
             params['start'] = start
-        if end is not None:
-            params['end'] = end
+        if stop is not None:
+            params['stop'] = stop
         if granularity is not None:
             params['granularity'] = granularity
         return self._send_message('get',


### PR DESCRIPTION
coinbasepro API documentation has an incorrect parameter name, that's why this function wasn't working. I changed params['end'] to params['stop'], and it works fine. I also took the liberty to tweak the doc string of this function based on my observations of its behavior.

Took it from direct tests in the browser itself + with help from this stackoverflow post:
https://stackoverflow.com/questions/51417285/coinbase-api-v2-getting-historic-price-for-multiple-days