### PR TITLE
Update setup.py python_requires formatting, for poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     author_email="acontry@gmail.com",
     url="https://github.com/acontry/coinbasepro",
     packages=setuptools.find_packages(),
-    python_requires=">=3.4.x",
+    python_requires=">=3.4",
     install_requires=requires,
     extras_require={
         "dev": [


### PR DESCRIPTION
Including this package in project that uses Poetry https://python-poetry.org/ fails with the error `Invalid python versions '>=3.4.x' on coinbasepro (0.4.0)` because the `python_requires` argument in `setup.py` is incorrectly formatted.

The [Python docs](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) show that it should be like `python_requires=">=3.4",` instead of the current format `python_requires=">=3.4.x",`