### PR TITLE
Move `get_signed_prices` method to auth client

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,14 @@ dev
 
 - [change here]
 
+0.4.1 (2023-02-18)
+++++++++++++++++++
+
+**Bugfixes**
+
+- Fix `python_requires` in setup.py so this package can be installed by poetry.
+- `get_signed_prices` should be an authenticated endpoint.
+
 0.4.0 (2022-07-28)
 ++++++++++++++++++
 

--- a/coinbasepro/auth_client.py
+++ b/coinbasepro/auth_client.py
@@ -1020,6 +1020,21 @@ class AuthenticatedClient(PublicClient):
         )
         return self._convert_dict(r, field_conversions)
 
+    def get_signed_prices(self) -> Dict[str, Any]:
+        """Get cryptographically signed prices.
+
+         Prices reported are ready to be posted on-chain using
+         Compound's Open Oracle smart contract.
+
+         Returns:
+             Signed price details.
+
+        Raises:
+            See `get_products()`.
+
+        """
+        return self._send_message("get", "/oracle", rate_limiter=self.p_rate_limiter)
+
     def withdraw(
         self, amount: Union[float, Decimal], currency: str, payment_method_id: str
     ) -> Dict[str, Any]:

--- a/coinbasepro/auth_client.py
+++ b/coinbasepro/auth_client.py
@@ -1033,7 +1033,7 @@ class AuthenticatedClient(PublicClient):
             See `get_products()`.
 
         """
-        return self._send_message("get", "/oracle", rate_limiter=self.p_rate_limiter)
+        return self._send_message("get", "/oracle", rate_limiter=self.a_rate_limiter)
 
     def withdraw(
         self, amount: Union[float, Decimal], currency: str, payment_method_id: str

--- a/coinbasepro/public_client.py
+++ b/coinbasepro/public_client.py
@@ -445,21 +445,6 @@ class PublicClient(object):
         )
         return self._convert_list_of_dicts(currencies, field_conversions)
 
-    def get_signed_prices(self) -> Dict[str, Any]:
-        """Get cryptographically signed prices.
-
-         Prices reported are ready to be posted on-chain using
-         Compound's Open Oracle smart contract.
-
-         Returns:
-             Signed price details.
-
-        Raises:
-            See `get_products()`.
-
-        """
-        return self._send_message("get", "/oracle", rate_limiter=self.p_rate_limiter)
-
     def get_time(self) -> Dict[str, Any]:
         """Get the API server time.
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = ["requests>=2.20.0"]
 
 setuptools.setup(
     name="coinbasepro",
-    version="0.4.0",
+    version="0.4.1",
     description="A Python interface for the Coinbase Pro/Coinbase Exchange API.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Per https://github.com/acontry/coinbasepro/issues/35 this method needs to be in the authenticated client.